### PR TITLE
new hdstats geomedian is preferred

### DIFF
--- a/BurnCube/BurnCube.py
+++ b/BurnCube/BurnCube.py
@@ -13,12 +13,17 @@ from shapely import geometry
 import os
 
 FASTGM=False
-try:
-    from pcm import gmpcm as geometric_median
-    print("PCM geomedian loaded")
-    FASTGM = True
-except ImportError:
-    from stats import geometric_median
+try: 
+    from hdstats import nangeomedian_pcm as geometric_median 
+    print("hdstats geomedian loaded") 
+except ImportError: 
+    try:
+        from pcm import gmpcm as geometric_median     
+        FASTGM = True 
+        print('PCM geomedian loaded') 
+    except ImportError: 
+        from stats import geometric_median 
+        print('stats geomedian loaded') 
 warnings.filterwarnings('ignore')
 
 


### PR DESCRIPTION
the hdstats geomedian is attempted first, if this doesn't work (like on the VDI) then it will try using the pcm geomedian, if this module isn't loaded, or the person doesn't have access then it will use the one in the stats code.